### PR TITLE
Fix unsigned short overflow

### DIFF
--- a/adafruit_waveform/sine.py
+++ b/adafruit_waveform/sine.py
@@ -41,5 +41,5 @@ def sine_wave(sample_frequency, pitch):
     length = int(sample_frequency / pitch)
     b = array.array("H", [0] * length)
     for i in range(length):
-        b[i] = int(math.sin(math.pi * 2 * i / length) * (2 ** 15) + 2 ** 15)
+        b[i] = int(math.sin(math.pi * 2 * i / length) * ((2 ** 15) - 1) + 2 ** 15)
     return b


### PR DESCRIPTION
Before:

```
>>> sine.sine_wave(100,1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sayler/Projects/Adafruit_CircuitPython_Waveform/adafruit_waveform/sine.py", line 44, in sine_wave
    b[i] = int(math.sin(math.pi * 2 * i / length) * (2 ** 15) + 2 ** 15)
OverflowError: unsigned short is greater than maximum
```

After:
```
>>> max(sine.sine_wave(100000,1))
65535
>>> min(sine.sine_wave(100000,1))
1
```

Fixes #9 