### PR TITLE
Correct pyproject.toml to correctly install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]
-py-modules = ["adafruit_waveform"]
+packages = ["adafruit_waveform"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
Fixes #23 which incorrectly described the library as a module (as opposed to package) in `pyproject.toml`.